### PR TITLE
Fix line-number-current-line box

### DIFF
--- a/haki-theme.el
+++ b/haki-theme.el
@@ -286,7 +286,7 @@ Respected Only in GUI frame"
    `(keycast-key                        ((,class :foreground ,bg-main)))
 ;;; --- line numbers
    `(line-number                        ((,class :inherit fixed-pitch :weight medium :foreground ,fg-inactive)))
-   `(line-number-current-line           ((,class :inherit fixed-pitch :weight ultra-bold :background ,fg-region :foreground ,fg-main :box ,haki-region)))
+   `(line-number-current-line           ((,class :inherit fixed-pitch :weight ultra-bold :background ,fg-region :foreground ,fg-main :box (:line-width (-1 . -1) :color ,haki-region))))
    `(line-number-major-tick             ((,class :inherit line-number :foreground ,error)))
    `(line-number-minor-tick             ((,class :inherit line-number :foreground ,fg-inactive)))
 


### PR DESCRIPTION
First of all, thanks a lot for your theme. Great work !

For the face `line-number-current-line`, you set a `:box` which, if unspecified, uses `:line-width (1 . 1)` which can creates a deformation on certain fonts and with certain sizes.

This deformation becomes very obvious when moving around :

https://github.com/idlip/haki/assets/67114640/03d8fe45-76b5-46ce-8f9f-c9177fbde793

This PR simply disables the `line-width`.

After fix :

https://github.com/idlip/haki/assets/67114640/40ffc639-bf14-4e56-be9c-c94f024e5059

The font used in these videos is Berkeley Mono with size 10.5